### PR TITLE
Add Code of Conduct template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+## Kata Containers Community Code of Conduct
+
+Kata Containers follows the [OpenStack Foundation Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/).


### PR DESCRIPTION
Adding in a Code of Conduct template that references the overall OSF Community Code of Conduct.

Signed-off-by: Jonathan Bryce <jbryce@jbryce.com>