### PR TITLE
Add link for #kata-general IRC channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,8 @@
                     <div class="col-6 mb-5 mt-5 left">
                         <h6 class="mb-2 mt-1">Communications</h6>
                         <p class="mb-1 mt-1"><a class="link" href="http://lists.katacontainers.io" target="_blank">Mailing list</a></p>
-                        <p class="mb-1 mt-1"><a class="link" href="http://webchat.freenode.net/?channels=kata-dev" target="_blank">Freenode IRC</a></p>
+                        <p class="mb-1 mt-1">Freenode IRC<br/><a class="link"
+                        href="http://webchat.freenode.net/?channels=kata-dev" target="_blank">#kata-dev</a> and<br/><a class="link" href="http://webchat.freenode.net/?channels=kata-general" target="_blank">#kata-general</a></p>
                         <p class="mb-1 mt-1"><a class="link" href="https://twitter.com/KataContainers" target="_blank">Twitter</a></p>
                         <p class="mb-1 mt-1">Slack <a class="link" href="https://katacontainers.slack.com/" target="_blank">channel</a> or <a class="link" href="http://bit.ly/KataSlack" target="_blank">invite</a></p>
                         <p class="mb-1 mt-1"><a class="link" href="https://www.facebook.com/KataContainers" target="_blank">Facebook</a></p>


### PR DESCRIPTION
A link was included for the developer focused #kata-dev
channel, but not the more user focused #kata-general.
This adds explicit links for both to the Communications
list.

Closes #35

Signed-off-by: Sean McGinnis <sean.mcginnis@huawei.com>