### PR TITLE
Renaming bitly URL

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -25,7 +25,7 @@ Kata Containers contributor metrics are available at [KataContainers.Biterg.io](
 
 ## Communications
 
-Slack: [bit.ly/KataSlack](https://katacontainers.slack.com/)  
+Slack: [bit.ly/katacontainersslack](http://bit.ly/katacontainersslack)  
 Freenode IRC: [#kata-dev](http://webchat.freenode.net/?channels=kata-dev) and [#kata-general](http://webchat.freenode.net/?channels=kata-general)  
 Mailing Lists: [lists.katacontainers.io/cgi-bin/mailman/listinfo](http://lists.katacontainers.io/cgi-bin/mailman/listinfo)  
 E-mail: [info@katacontainers.io](mailto:info@katacontainers.io)  


### PR DESCRIPTION
- Switching out the bitly since the origin expired.

Signed-off-by: Jimmy McArthur <jimmy@tipit.net>