### PR TITLE
Restores Netlify CMS editorial workflow.

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -10,6 +10,7 @@ backend:
     uploadMedia: '[skip ci] Upload “{{path}}”'
     deleteMedia: '[skip ci] Delete “{{path}}”'
 
+publish_mode: editorial_workflow
 media_folder: static/img
 public_folder: /img
 


### PR DESCRIPTION
Instead of having all CMS save or edits be committed directly into repo, editorial workflow translates CMS actions into common git commands:

When you:
- Save a draft -> it commits to a new branch (named according to the pattern cms/collectionName/entrySlug), and opens a pull request.
- Edit draft -> it pushes another commit to the draft branch/pull request.
- Approve and publish draft -> it merges pull request and deletes branch.


