### PR TITLE
IRC: Point to OFTC channels

### DIFF
--- a/src/content/footer-nav.json
+++ b/src/content/footer-nav.json
@@ -34,11 +34,11 @@
         },
         {
           "text": "IRC: #kata-dev",
-          "link": "http://webchat.freenode.net/?channels=kata-dev"
+          "link": "http://webchat.oftc.net/?channels=kata-dev"
         },
         {
           "text": "IRC: #kata-general",
-          "link": "http://webchat.freenode.net/?channels=kata-general"
+          "link": "http://webchat.oftc.net/?channels=kata-general"
         }
       ]
     },

--- a/src/pages/community/index.md
+++ b/src/pages/community/index.md
@@ -28,7 +28,7 @@ Kata Containers contributor metrics are available at [KataContainers.Biterg.io](
 ## Communications
 
 Slack: [bit.ly/katacontainersslack](http://bit.ly/katacontainersslack)\
-Freenode IRC: [\#kata-dev](http://webchat.freenode.net/?channels=kata-dev) and [\#kata-general](http://webchat.freenode.net/?channels=kata-general)\
+OFTC IRC: [\#kata-dev](http://webchat.oftc.net/?channels=kata-dev) and [\#kata-general](http://webchat.oftc.net/?channels=kata-general)\
 Mailing Lists: [lists.katacontainers.io/cgi-bin/mailman/listinfo](http://lists.katacontainers.io/cgi-bin/mailman/listinfo)\
 E-mail: <mailto:info@katacontainers.io>\
 Twitter: [@katacontainers](https://twitter.com/katacontainers)  


### PR DESCRIPTION
Freenode is no longer the home of the kata-containers IRC channels.
Following the announcement on our mailing list, we've moved to OFTC:
http://lists.katacontainers.io/pipermail/kata-dev/2021-May/001938.html

Fixes: #149

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>