### PR TITLE
docs: Update url for contribution guide

### DIFF
--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -40,4 +40,4 @@ Design and Implementations
 How to Contribute
 
 * [Developer Guide](https://github.com/kata-containers/kata-containers/tree/main/docs/Developer-Guide.md) : Setup the Kata Containers developing environments
-* [How to contribute to Kata Containers](https://github.com/kata-containers/kata-containers/tree/main/docs/CONTRIBUTING.md)
+* [How to contribute to Kata Containers](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
This updates to the proper url for the contribution guide.

Fixes: #151

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>