### PR TITLE
config: Use `main` branch instead of `master`

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
   repo: kata-containers/www.katacontainers.io
-  branch: master # Branch to update (optional; defaults to master)
+  branch: main # Branch to update (optional; defaults to master)
   commit_messages:
     create: 'Create {{collection}} “{{slug}}”'
     update: 'Update {{collection}} “{{slug}}”'


### PR DESCRIPTION
It seems that the only required change is to switch the backend branch
from `master` to `main`, and theoretically we should be good to go to
fully switch to using `main` on *all* repos which are part of the
kata-containers organization.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>