### PR TITLE
Fixed: link to architecture docs.

### DIFF
--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -34,7 +34,7 @@ Understand the basics, contribute to and try using Kata Containers.
 
 Design and Implementations
 
-* [Kata Containers Architecture](https://github.com/kata-containers/kata-containers/tree/main/docs/design/architecture.md) : Architectural overview of Kata Containers
+* [Kata Containers Architecture](https://github.com/kata-containers/kata-containers/tree/main/docs/design/architecture) : Architectural overview of Kata Containers
 * [Kata Containers design](https://github.com/kata-containers/kata-containers/tree/main/docs/design) : More Kata Containers design documents
 
 How to Contribute


### PR DESCRIPTION
This was previously a single markdown file.
It was updated to a directory in:
https://github.com/kata-containers/kata-containers/commit/6f9efb4043f38a384d4f07c5e545a3377c0759ff#diff-20c51aad7f36c9befb2e1ebef90660ea47b2a30e84c56235baea581c5001b8a8

Signed-off-by: Agam Dua <agam_dua@apple.com>