### PR TITLE
top banner Summit promo

### DIFF
--- a/src/content/top-bar.json
+++ b/src/content/top-bar.json
@@ -1,7 +1,7 @@
 {
   "bar": {
-    "text": "Learn more about Ant Group's Kata Containers production use case at the OpenInfra Live Keynotes",
-    "link": "https://www.youtube.com/playlist?list=PLKqaoAnDyfgo5sOi98QlbMVMhgI_lxFPA",
-    "button": "WATCH NOW"
+    "text": "Collaborate directly with people running containers at scale at the OpenInfra Summit Berlin, June 7-9 2022",
+    "link": "https://openinfra.dev/summit/",
+    "button": "LEARN MORE"
   }
 }


### PR DESCRIPTION
Replacing the OpenInfra Live Keynotes video announcement with a promo for the OpenInfra Summit in Berlin