### PR TITLE
update slack link in index page

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -70,7 +70,7 @@ tables:
           <p className="p-simple-item-bullet">Join the mailing list: <a
           href="http://lists.katacontainers.io">http://lists.katacontainers.io</a></p>
           <p className="p-simple-item-bullet">Slack: <a
-          href="http://bit.ly/kataslack">bit.ly/kataslack</a>  IRC: <a
+          href="https://join.slack.com/t/katacontainers/shared_invite/zt-16w1u6usn-sK871qbMxVN8KsCP5Gr56A">slack.com</a>  IRC: <a
           href="#kata-dev">#kata-dev</a></p>      
         title: Stay in the loop
       - text: >


### PR DESCRIPTION
The slack link in the community page has been updated, but the index page was forgotten.

Signed-off-by: liubin <liubin0329@gmail.com>