### PR TITLE
Add link to blog submission guidelines

### DIFF
--- a/src/content/blog-config.json
+++ b/src/content/blog-config.json
@@ -32,5 +32,11 @@
       "text": "Twitter",
       "link": "https://twitter.com/katacontainers"
     }    
+  ],
+  "share": [
+    {
+      "text": "How to Contribute a Blog Post",
+      "link": "https://github.com/kata-containers/kata-containers/blob/main/docs/Blog-Post-Submission-Guide.md"
+    }
   ]
 }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -84,6 +84,18 @@ export default class BlogIndexPage extends React.Component {
                         </div>
                       </li>
                     }
+                    {blogConfig.connect.length > 0 &&
+                      <li className="widget item-no-bullet">
+                        <div className="widget-head">
+                          <h6 className="widget-title">Share Your Story</h6>
+                        </div>
+                        <div className="widget-body">
+                          <ul className="widget-list">
+                            {blogConfig.share.map(link => <li className="item-no-bullet" key={link.link}><a href={link.link} target="_blank" rel="noopener noreferrer">{link.text}</a></li>)}
+                          </ul>
+                        </div>
+                      </li>
+                    }
                   </ul>
                 </aside>
               </div>


### PR DESCRIPTION
This patch adds a link to the new description in the Kata Containers docs about how to contribute a new blog post to the website.