### PR TITLE
Add Kata AI blog post

### DIFF
--- a/src/pages/blog/kata-containers-for-ai-workloads.md
+++ b/src/pages/blog/kata-containers-for-ai-workloads.md
@@ -15,27 +15,27 @@ Considering the large amounts, most often sensitive, data in the fast-evolving w
 # Emerging AI Use Cases
 While it will still take time for AI to reach its full potential in production, there are various use cases where it is already applicable.
 
-- Natural Language Processing (NLP) and Chatbots - AI tools are now able to take instructions through human language, and therefore interact with people in both private and business context. Most of us in the modern world have talked to AI chatbots countless times already. While the experience still varies, this use case already provides value.
-- Computer Vision - Video processing and image recognition is getting increasingly important with applications such as surveillance, self-driving cars or diagnostic imaging in healthcare.
-- Predictive Analytics - Modern systems and infrastructures are complex, which makes maintenance a hard task. With being able to analyze large amounts of data that have been collected during the operation of these systems, failures can be fixed faster or even prevented before they occur.
-- Recommendation Systems - Whenever we use a tool, think of buying something in an online store or watching shows on a streaming platform, most of them offer you with suggestions based on the patterns they recognize about you. These recommendations are being powered by AI in the background.
-- Fraud Detection and Cybersecurity - This use case is increasingly important as we conduct more and more of our lives online, think of financial transactions or online medical services. These transactions need to be monitored and secured to detect and avoid malicious actions, fraudulent activities and cyber threats.
+- **Natural Language Processing (NLP) and Chatbots** - AI tools are now able to take instructions through human language, and therefore interact with people in both private and business context. Most of us in the modern world have talked to AI chatbots countless times already. While the experience still varies, this use case already provides value.
+- **Computer Vision** - Video processing and image recognition is getting increasingly important with applications such as surveillance, self-driving cars or diagnostic imaging in healthcare.
+- **Predictive Analytics** - Modern systems and infrastructures are complex, which makes maintenance a hard task. With being able to analyze large amounts of data that have been collected during the operation of these systems, failures can be fixed faster or even prevented before they occur.
+- **Recommendation Systems** - Whenever we use a tool, think of buying something in an online store or watching shows on a streaming platform, most of them offer you with suggestions based on the patterns they recognize about you. These recommendations are being powered by AI in the background.
+- **Fraud Detection and Cybersecurity** - This use case is increasingly important as we conduct more and more of our lives online, think of financial transactions or online medical services. These transactions need to be monitored and secured to detect and avoid malicious actions, fraudulent activities and cyber threats.
 
 What is your AI use case?
 
 # Why Kata Containers for AI?
 Common characteristics of AI workloads often involve handling sensitive data and running complex, resource-intensive processes. Traditional containers, while lightweight and fast, may fall short in providing the necessary isolation for high-security environments. On the other hand, VMs offer strong isolation but at the cost of performance. Kata Containers bridges this gap, delivering the best of both worlds.
 
-- Enhanced Security: Kata Containers run each workload in its own lightweight VM, ensuring strong isolation. This is crucial for AI applications dealing with sensitive data, such as healthcare and finance, where data breaches can have severe consequences. Data protection is further increased through the project’s tight integration with Confidential Containers, which relies on confidential computing technology.
-- Performance Efficiency: Unlike traditional VMs, Kata Containers is designed to be fast and resource-efficient. This efficiency is vital for AI workloads that require quick deployment and scaling, such as real-time data analysis and machine learning (ML) model training.
-- Scalability: AI applications often need to scale quickly to handle varying workloads. Kata Containers support rapid scaling without compromising security, making them ideal for dynamic AI environments.
+- **Enhanced Security**: Kata Containers run each workload in its own lightweight VM, ensuring strong isolation. This is crucial for AI applications dealing with sensitive data, such as healthcare and finance, where data breaches can have severe consequences. Data protection is further increased through the project’s tight integration with Confidential Containers, which relies on confidential computing technology.
+- **Performance Efficiency**: Unlike traditional VMs, Kata Containers is designed to be fast and resource-efficient. This efficiency is vital for AI workloads that require quick deployment and scaling, such as real-time data analysis and machine learning (ML) model training.
+- **Scalability**: AI applications often need to scale quickly to handle varying workloads. Kata Containers support rapid scaling without compromising security, making them ideal for dynamic AI environments.
 
 # AI Workloads Benefiting from Kata Containers
 The below examples show how Kata can be utilized for various AI workloads.
 
-- Machine Learning Model Training: Training ML models involves processing large datasets and requires significant computational power. Kata Containers provide the necessary isolation and efficiency, ensuring secure and scalable model training environments.
-- Inference and Real-Time Data Processing: AI applications like fraud detection and recommendation systems rely on real-time data processing. The low latency and high efficiency of Kata Containers make it suitable for these time-sensitive tasks.
-- Data Analytics: Analyzing vast amounts of data for insights, like predictions and preventative actions, is a common AI workload. Kata Containers combined with CoCo offer a secure and efficient environment for running complex data analytics, enhancing performance and ensuring data integrity.
+- **Machine Learning Model Training**: Training ML models involves processing large datasets and requires significant computational power. Kata Containers provide the necessary isolation and efficiency, ensuring secure and scalable model training environments.
+- **Inference and Real-Time Data Processing**: AI applications like fraud detection and recommendation systems rely on real-time data processing. The low latency and high efficiency of Kata Containers make it suitable for these time-sensitive tasks.
+- **Data Analytics**: Analyzing vast amounts of data for insights, like predictions and preventative actions, is a common AI workload. Kata Containers combined with CoCo offer a secure and efficient environment for running complex data analytics, enhancing performance and ensuring data integrity.
 
 In conclusion, Kata Containers is a powerful container runtime that is highly suitable for AI workloads, combining the best features of VMs and containers. Its enhanced security, performance efficiency, and scalability make it an ideal choice for various AI applications, driving reliability, security and data protection in AI projects. As a practical example, see the NVIDIA use case on the [Use Cases page](https://katacontainers.io/use-cases/) on the project’s website.
 

--- a/src/pages/blog/kata-containers-for-ai-workloads.md
+++ b/src/pages/blog/kata-containers-for-ai-workloads.md
@@ -1,0 +1,44 @@
+---
+templateKey: blog-post
+title: Kata Containers: Revolutionizing AI Workloads
+author: Ildiko Vancsa
+date: 2024-07-0119T01:32:05.627Z
+category:
+  - value: category-edic1zzR0
+    label: News & Announcements
+---
+
+Artificial Intelligence (AI) turned from news headline to reality almost overnight, and started to provide enhanced automation to both individuals as well as businesses, and with that increase efficiency and productivity. While it’s often looked at as a tool to increase output and revenue generation, it also has the potential to transform workspaces and increase creativity.
+
+Considering the large amounts, most often sensitive, data in the fast-evolving world of AI, the performance and security of the infrastructure running AI workloads are crucial. Kata Containers, the open-source secure container runtime project, addresses these needs by offering lightweight virtual machines (VMs) that provide the isolation and security of traditional VMs with the speed and efficiency of containers. Kata Containers is also working closely together with the [Confidential Containers (CoCo)](https://www.cncf.io/projects/confidential-containers/) project in the CNCF ecosystem, to further enhance data protection based on confidential computing technology.
+
+# Emerging AI Use Cases
+While it will still take time for AI to reach its full potential in production, there are various use cases where it is already applicable.
+
+- Natural Language Processing (NLP) and Chatbots - AI tools are now able to take instructions through human language, and therefore interact with people in both private and business context. Most of us in the modern world have talked to AI chatbots countless times already. While the experience still varies, this use case already provides value.
+- Computer Vision - Video processing and image recognition is getting increasingly important with applications such as surveillance, self-driving cars or diagnostic imaging in healthcare.
+- Predictive Analytics - Modern systems and infrastructures are complex, which makes maintenance a hard task. With being able to analyze large amounts of data that have been collected during the operation of these systems, failures can be fixed faster or even prevented before they occur.
+- Recommendation Systems - Whenever we use a tool, think of buying something in an online store or watching shows on a streaming platform, most of them offer you with suggestions based on the patterns they recognize about you. These recommendations are being powered by AI in the background.
+- Fraud Detection and Cybersecurity - This use case is increasingly important as we conduct more and more of our lives online, think of financial transactions or online medical services. These transactions need to be monitored and secured to detect and avoid malicious actions, fraudulent activities and cyber threats.
+
+What is your AI use case?
+
+# Why Kata Containers for AI?
+Common characteristics of AI workloads often involve handling sensitive data and running complex, resource-intensive processes. Traditional containers, while lightweight and fast, may fall short in providing the necessary isolation for high-security environments. On the other hand, VMs offer strong isolation but at the cost of performance. Kata Containers bridges this gap, delivering the best of both worlds.
+
+- Enhanced Security: Kata Containers run each workload in its own lightweight VM, ensuring strong isolation. This is crucial for AI applications dealing with sensitive data, such as healthcare and finance, where data breaches can have severe consequences. Data protection is further increased through the project’s tight integration with Confidential Containers, which relies on confidential computing technology.
+- Performance Efficiency: Unlike traditional VMs, Kata Containers is designed to be fast and resource-efficient. This efficiency is vital for AI workloads that require quick deployment and scaling, such as real-time data analysis and machine learning (ML) model training.
+- Scalability: AI applications often need to scale quickly to handle varying workloads. Kata Containers support rapid scaling without compromising security, making them ideal for dynamic AI environments.
+
+# AI Workloads Benefiting from Kata Containers
+The below examples show how Kata can be utilized for various AI workloads.
+
+- Machine Learning Model Training: Training ML models involves processing large datasets and requires significant computational power. Kata Containers provide the necessary isolation and efficiency, ensuring secure and scalable model training environments.
+- Inference and Real-Time Data Processing: AI applications like fraud detection and recommendation systems rely on real-time data processing. The low latency and high efficiency of Kata Containers make it suitable for these time-sensitive tasks.
+- Data Analytics: Analyzing vast amounts of data for insights, like predictions and preventative actions, is a common AI workload. Kata Containers combined with CoCo offer a secure and efficient environment for running complex data analytics, enhancing performance and ensuring data integrity.
+
+In conclusion, Kata Containers is a powerful container runtime that is highly suitable for AI workloads, combining the best features of VMs and containers. Its enhanced security, performance efficiency, and scalability make it an ideal choice for various AI applications, driving reliability, security and data protection in AI projects. As a practical example, see the NVIDIA use case on the [Use Cases page](https://katacontainers.io/use-cases/) on the project’s website.
+
+# About Kata Containers
+
+If you would like to learn more about the project and get involved check out the [website](https://www.katacontainers.io) for more information or [download the code](https://github.com/kata-containers) and start to experiment with the runtime. If you are already evaluating or using the software please fill out the [user survey](https://openinfrafoundation.formstack.com/forms/kata_containers_user_survey) and help the community improve the project based on your feedback.

--- a/src/pages/blog/kata-containers-for-ai-workloads.md
+++ b/src/pages/blog/kata-containers-for-ai-workloads.md
@@ -1,8 +1,8 @@
 ---
 templateKey: blog-post
-title: Kata Containers: Revolutionizing AI Workloads
+title: Kata Containers - Revolutionizing AI Workloads
 author: Ildiko Vancsa
-date: 2024-07-0119T01:32:05.627Z
+date: 2024-07-01T01:32:05.627Z
 category:
   - value: category-edic1zzR0
     label: News & Announcements


### PR DESCRIPTION
This commit adds a new blog post to the Kata Containers blog to capture the projects general applicability to the AI tools and  applications, and with that highlighting the projct's relevance and importance in the space.