### PR TITLE
Fix line break in docs page

### DIFF
--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -23,7 +23,7 @@ Understand the basics, contribute to and try using Kata Containers.
 
 [Upgrading](https://github.com/kata-containers/kata-containers/tree/main/docs/Upgrading.md) : How to upgrade from Clear Containers and runV to Kata Containers and how to upgrade an existing Kata Containers system to the latest version.  
 [Limitations](https://github.com/kata-containers/kata-containers/tree/main/docs/Limitations.md) : Differences and limitations compared with the default Docker runtime, runc.  
-[How to](https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-use-k8s-with-containerd-and-kata.md) : Kata Containers and containerd with Kubernetes.
+[How to](https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-use-k8s-with-containerd-and-kata.md) : Kata Containers and containerd with Kubernetes.  
 [How to](https://github.com/kata-containers/kata-containers/tree/main/docs/use-cases/zun_kata.md) : OpenStack Zun with Kata Containers.  
 [How to](https://github.com/kata-containers/kata-containers/tree/main/docs/how-to#hypervisors-integration) : Kata Containers with Firecracker.
 


### PR DESCRIPTION
Add two spaces at the end of line as a line break to user guide section.

Current docs page:

![kata-docs-page-user-guides](https://github.com/user-attachments/assets/b893d0ad-2c8e-4b84-9c82-4fb1d1302846)
