### PR TITLE
Add new blog post to announce new AC members

### DIFF
--- a/src/pages/blog/kata-containers-ac-october-2024-election-results.md
+++ b/src/pages/blog/kata-containers-ac-october-2024-election-results.md
@@ -1,0 +1,44 @@
+---
+templateKey: blog-post
+title: Welcome Kata Containers’ new and returning Architecture Committee members!
+author: Ildiko Vancsa
+date: 2024-10-29T01:32:05.627Z
+category:
+  - value: category-edic1zzR0
+    label: News & Announcements
+---
+
+The [Architecture Committee (AC)](https://github.com/kata-containers/community/tree/main/elections#architecture-committee-responsibilities) is a leadership body that oversees the architectural direction of the Kata Containers project and is also responsible for ensuring that the community is open, welcoming and collaborating efficiently. The committee is composed of 7 members, who serve for 1-year terms.
+
+To ensure leadership continuity, while also providing opportunity for new leaders to arise, the committee seats are renewed in a staggered election process twice a year. The recent AC election has just concluded, where 3 AC seats were filled. The next election, that is coming up in 6 months, will renew the other 4 seats. The election is administered by election officials, who are also active members of the community and not running in the election themselves.
+
+In the recent AC election, initially 4 candidates announced their nomination for the 3 open seats. With one of the candidates withdrawing their nomination during the campaign phase, election officials were able to announce the new AC without the need for a voting period. Congratulations to the new and reelected members of the Kata AC!
+
+The new Kata Containers Architecture Committee:
+- Anastassios Nanos, Nubificus Ltd
+- Aurélien Bombo, Microsoft
+- Fupan Li, Ant Group
+- Greg Kurz, Red Hat
+- Steve Horsman, IBM
+- Tao Peng, Ant Group
+- Zvonko Kaiser, NVIDIA
+
+# Meet the newly elected Kata AC members
+
+## Aurélien Bombo, Microsoft
+
+Aurélien is a Software Engineer at Microsoft with a focus on Linux and container technologies. He has been actively involved, and being part of the core team of Kata Containers for over a year now. Aurélien’s main focus area within the community is CI and testing. More recently, he also took on the responsibility of mentoring students in a mentorship program, as part of a partnership with Boston University. The students are currently working designing and implementing a CI dashboard, with guidance from Aurélien and other contributors from the Kata community.
+
+## Fupan Li, Ant Group
+
+Fupan is a Senior Engineer at Ant Group, who's running the largest Kata Containers cluster in the ecosystem. His focus within the company is also Kata Containers, to ensure seamless integration of the project into Ant Groups use cases. Fupan has been an active core member of the Kata community since 2018. Over the years he’s been working on some of the core functions of the project to enhance performance and simplify its architecture. Recently he is more focused on the work to implement the Kata runtime in Rust, and authored the Rust version of the kata-agent. Fupan is a returning AC member.
+
+## Greg Kurz, Red Hat
+
+Greg is a Senior Software Engineer at Red Hat. As part of his role, Greg is working on OpenShift and focuses on enabling Kata Containers in the platform. When he joined the Kata Containers project 3 years ago, his focus was more on the virtualization component and QEMU, but since then he’s extended his scope to the entire stack. Greg started in the project as a software developer, and quickly evolved his responsibilities to perform reviews and become a project maintainer. His recent focus areas include CI and improving review quality and efficiency. Greg is a returning AC member.
+
+Congratulations to the new Architecture Committee members, and thanks to everyone who participated in the election! Governance by community-elected officials is one of the cornerstones of the Four Opens, which are the guiding principles of the Kata Containers and other OpenInfra communities to build and sustain open, collaborative and welcoming environments.
+
+# About Kata Containers
+
+If you would like to learn more about the project and get involved check out the [website](https://katacontainers.io) for more information or [download the code](https://github.com/kata-containers) and start to experiment with the runtime. If you are already evaluating or using the software please fill out the [user survey](https://openinfrafoundation.formstack.com/forms/kata_containers_user_survey) and help the community improve the project based on your feedback.


### PR DESCRIPTION
This patch adds a short blog post that announces the new Kata AC members after the recent election has just concluded.