### PR TITLE
Updating outdated link to install docs

### DIFF
--- a/src/pages/community/index.md
+++ b/src/pages/community/index.md
@@ -16,7 +16,7 @@ Kata Containers is open source, which means it relies on contributors like you! 
 
 ## How to Contribute
 
-Installation Guides: [View the docs](https://github.com/kata-containers/documentation/tree/master/install)\
+Installation Guides: [View the docs](https://github.com/kata-containers/kata-containers/tree/main/docs/install)\
 GitHub Repo: [github.com/kata-containers](https://github.com/kata-containers)\
 Onboarding Deck: [View the presentation](https://www.katacontainers.io/collateral/kata-containers-overview-july22.pdf)\
 Overview One Pager: [View the PDF](https://katacontainers.io/collateral/kata-containers-1pager.pdf)  


### PR DESCRIPTION
The COmmunity page of the website has a link to the install documentation. The old link pointed to a 'documentation' repo, which is now archived. This patch adds the link to the current docs.