### PR TITLE
Replace old architecture diagram

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -36,7 +36,7 @@ mainpitch:
         Foundation, which supports the development and adoption of open
         infrastructure globally. The code is hosted at GitHub under the Apache 2
         license.
-  image: /img/kata-explained1@2x.png
+  image: /img/katacontainers_architecture_diagram.jpg
   title: About Kata Containers
 features:
   rows:

--- a/src/pages/software/index.md
+++ b/src/pages/software/index.md
@@ -31,7 +31,7 @@ architecture:
       link: 'https://github.com/kata-containers/documentation'
       linkText: Get Started
       title: View the Documentation
-  image: /img/kata-explained1@2x.png
+  image: /img/katacontainers_architecture_diagram.jpg
   title: Architecture
 integration:
   image: /img/katacontainers_kubernetes_integration_diagram.jpg

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -47,7 +47,7 @@ export const IndexPageTemplate = ({
         <article className="article level">
           <ZoomImage
             src={mainpitch.image?.childImageSharp?.fluid?.src || mainpitch.image}
-            alt="/kata-explained1@2x.png"
+            alt="/katacontainers_architecture_diagram.jpg"
           />
           <div className="article-content">
             <div className="article__entry">


### PR DESCRIPTION
This patch replaces the old architecture diagram everywhere on the website with the v2 version.