### PR TITLE
Remove IRC information from the website

### DIFF
--- a/src/content/footer-nav.json
+++ b/src/content/footer-nav.json
@@ -37,12 +37,8 @@
           "link": "https://twitter.com/KataContainers"
         },
         {
-          "text": "IRC: #kata-dev",
-          "link": "http://webchat.oftc.net/?channels=kata-dev"
-        },
-        {
-          "text": "IRC: #kata-general",
-          "link": "http://webchat.oftc.net/?channels=kata-general"
+          "text": "Slack: #general",
+          "link": "https://join.slack.com/t/katacontainers/shared_invite/zt-16w1u6usn-sK871qbMxVN8KsCP5Gr56A"
         }
       ]
     },

--- a/src/pages/community/index.md
+++ b/src/pages/community/index.md
@@ -28,7 +28,6 @@ Kata Containers contributor metrics are available at [KataContainers.Biterg.io](
 ## Communications
 
 Slack: [Kata Slack](https://join.slack.com/t/katacontainers/shared_invite/zt-16w1u6usn-sK871qbMxVN8KsCP5Gr56A)\
-OFTC IRC: [\#kata-dev](http://webchat.oftc.net/?channels=kata-dev) and [\#kata-general](http://webchat.oftc.net/?channels=kata-general)\
 Mailing Lists: [lists.katacontainers.io/cgi-bin/mailman/listinfo](http://lists.katacontainers.io/cgi-bin/mailman/listinfo)\
 E-mail: <mailto:info@katacontainers.io>\
 Bluesky: [@katacontainers.io](https://bsky.app/profile/katacontainers.io)\

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -70,8 +70,7 @@ tables:
           <p className="p-simple-item-bullet">Join the mailing list: <a
           href="http://lists.katacontainers.io">http://lists.katacontainers.io</a></p>
           <p className="p-simple-item-bullet">Slack: <a
-          href="https://join.slack.com/t/katacontainers/shared_invite/zt-16w1u6usn-sK871qbMxVN8KsCP5Gr56A">slack.com</a>  IRC: <a
-          href="#kata-dev">#kata-dev</a></p>      
+          href="https://join.slack.com/t/katacontainers/shared_invite/zt-16w1u6usn-sK871qbMxVN8KsCP5Gr56A">slack.com</a></p>      
         title: Stay in the loop
       - text: >
           <p>Updates from the community on a weekly basis.</p>  <p


### PR DESCRIPTION
The Kata community has been using Slack and completely moved off of IRC. This patch updates the website to remove the pointers to the old IRC channels.