### PR TITLE
netlify: netlify dev fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ src/content/sponsored-projects.json
 .env
 .env.*
 .idea/
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,14 @@
 [build.environment]
   YARN_VERSION = "1.13.0"
   YARN_FLAGS = "--no-ignore-optional"
+# Local `netlify dev`: run Gatsby over plain HTTP (no --S) so Netlify Dev can
+# proxy to it. Netlify serves the proxy on `port` and forwards to `targetPort`.
+[dev]
+  command = "yarn develop:http"
+  framework = "#custom"
+  targetPort = 8000
+  port = 8888
+  publish = "public"
 # Deploy Preview context: all deploys resulting from a pull/merge request will
 # inherit these settings.
 [[redirects]]

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gatsby-clean": "gatsby clean",
     "build": "yarn clean && gatsby build",
     "develop": "NODE_ENV=development NODE_OPTIONS=--max-old-space-size=8192 npm run gatsby-clean && node --trace-warnings node_modules/.bin/gatsby develop --S -H 0.0.0.0",
+    "develop:http": "NODE_ENV=development NODE_OPTIONS=--max-old-space-size=8192 npm run gatsby-clean && node --trace-warnings node_modules/.bin/gatsby develop -H 0.0.0.0",
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"{gatsby-*.js,src/**/*.js}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The README stated that we can use `netlify dev` to start the dev server, but it did not actually work. This commit fixes it.