### PR TITLE
Update footer with new link

### DIFF
--- a/src/content/footer-nav.json
+++ b/src/content/footer-nav.json
@@ -59,7 +59,7 @@
         },
         {
           "text": "Security vulnerabilities",
-          "link": "https://github.com/kata-containers/community?tab=readme-ov-file#vulnerability-handling"
+          "link": "https://github.com/kata-containers/kata-containers/blob/main/SECURITY.md"
         }
       ]
     }


### PR DESCRIPTION
This patch updates the link to the new documentation the Kata Containers community is using to describe their security vulnerability process to users and contributors.